### PR TITLE
Fixed "Goals List" link.

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Following maven goals has been implemented in this plugin :
 8. aion4j:deploy - Extend the deploy goal for remote deployment.
 9. aion4j:postpack - Post process the jar after build. Example: Abi Compile to process @Callable annotation. Default phase "package"
 
-For all the supported goals, check this [page](https://github.com/satran004/aion4j-maven-plugin/wiki/Aion4j-Maven-Plugin---Goals-(In-Progress)).
+For all the supported goals, check this [page](https://github.com/bloxbean/aion4j-maven-plugin/wiki/Aion4j-Maven-Plugin---Goals-(In-Progress)).
 
 [Quick Start Guide](https://github.com/satran004/aion4j-maven-plugin/wiki/Quick-Start-with-embedded-AVM)
 


### PR DESCRIPTION
The link for the Goals List was pointing to the old Wiki. It now points to the current Bloxbean wiki.