### PR TITLE
Fixed grammar issue with receipt error message.

### DIFF
--- a/src/main/java/org/aion4j/maven/avm/mojo/AVMGetReceiptMojo.java
+++ b/src/main/java/org/aion4j/maven/avm/mojo/AVMGetReceiptMojo.java
@@ -98,7 +98,7 @@ public class AVMGetReceiptMojo extends AVMBaseMojo {
         }
 
         if(counter == maxCountrer) {
-            log.info("Waited too much for the receipt. Something is wrong.");
+            log.info("Waited too long for the receipt, something is wrong.");
         }
     }
 


### PR DESCRIPTION
Just changed a couple of words in an error message. This message is shown when the node takes too long to send a receipt.